### PR TITLE
Improve EnumSchema validation error

### DIFF
--- a/lib/rschema.rb
+++ b/lib/rschema.rb
@@ -253,7 +253,7 @@ module RSchema
       if value_set.include?(value_walked)
         value_walked
       else
-        RSchema::ErrorDetails.new(value_walked, "is not a valid enum member")
+        RSchema::ErrorDetails.new(value_walked, "is not one of #{value_set.to_a}")
       end
     end
 

--- a/spec/rschema_spec.rb
+++ b/spec/rschema_spec.rb
@@ -84,8 +84,8 @@ RSpec.describe RSchema do
       expect{ RSchema.validate!(schema, true) }.not_to raise_error
       expect{ RSchema.validate!(schema, false) }.not_to raise_error
 
-      expect{ RSchema.validate!(schema, nil) }.to raise_error
-      expect{ RSchema.validate!(schema, 5) }.to raise_error
+      expect{ RSchema.validate!(schema, nil) }.to raise_error(RSchema::ValidationError)
+      expect{ RSchema.validate!(schema, 5) }.to raise_error(RSchema::ValidationError)
     end
 
     it 'validates anything' do


### PR DESCRIPTION
This makes the enum-error a bit more user-friendly; it tells what values are permitted.

It also fixes some rspec-warnings about `raise_error`.